### PR TITLE
Add directive to allow timeout before redirecting

### DIFF
--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -187,7 +187,7 @@ angular.module('angulartics', [])
   }
 
   function isProperty(name) {
-    return name.substr(0, 9) === 'analytics' && ['On', 'Event'].indexOf(name.substr(9)) === -1;
+    return name.substr(0, 9) === 'analytics' && ['On', 'Event', 'LinkTimeout'].indexOf(name.substr(9)) === -1;
   }
 
   return {
@@ -209,5 +209,40 @@ angular.module('angulartics', [])
       });
     }
   };
+}])
+
+.directive('analyticsLinkTimeout', ['$analytics', '$timeout', function ($analytics, $timeout) {
+  function isMeta (e) {
+    if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) return true;
+
+    // Logic that handles checks for the middle mouse button, based
+    // on [jQuery](https://github.com/jquery/jquery/blob/master/src/event.js#L466).
+    var which = e.which, button = e.button;
+    if (!which && button !== undefined) {
+      return (!button & 1) && (!button & 2) && (button & 4);
+    } else if (which === 2) {
+      return true;
+    }
+
+    return false;
+  };
+
+  return {
+    restrict: 'A',
+    scope: false,
+    link: function($scope, $element, $attrs) {
+      var timeout = $attrs.analyticsTrackLink || 300;
+
+      angular.element($element[0]).bind('click', function (event) {
+        if (this.href && this.target !== '_blank' && !isMeta(event)) {
+          event.preventDefault();
+          var redirect = function (href) {
+            $timeout(function() { window.location.href = href; }, timeout);
+          }
+          redirect(this.href)
+        }
+      });
+    }
+  }
 }]);
 })(angular);

--- a/src/angulartics.js
+++ b/src/angulartics.js
@@ -231,7 +231,7 @@ angular.module('angulartics', [])
     restrict: 'A',
     scope: false,
     link: function($scope, $element, $attrs) {
-      var timeout = $attrs.analyticsTrackLink || 300;
+      var timeout = $attrs.analyticsLinkTimeout || 300;
 
       angular.element($element[0]).bind('click', function (event) {
         if (this.href && this.target !== '_blank' && !isMeta(event)) {


### PR DESCRIPTION
Inserts an optional timeout before redirecting that link. This gives the
browser enough time to fire requests before redirecting.

Default timeout is 300ms but users can override this.

Based on: https://segment.io/docs/libraries/analytics.js/#track-link
Fixes: https://github.com/luisfarzati/angulartics/issues/148

Totally open to suggestions. I'm using this in production already as it's necessary for tracking our link clicks that have browser redirects (ones not using angular internal routing).