### PR TITLE
Add support for hitCallback in GA when using field object

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -60,7 +60,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 		eventLabel: properties.label ||  null,
 		eventValue: properties.value || null,
 		nonInteraction: properties.noninteraction || null,
-    hitCallback: properties.hitcallback || null
+		hitCallback: properties.hitcallback || null
 	  };
 
 	  // add custom dimensions and metrics

--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -30,7 +30,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    * @name eventTrack
    *
    * @param {string} action Required 'action' (string) associated with the event
-   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional  fields 'label' (string), 'value' (integer) and 'noninteraction' (boolean)
+   * @param {object} properties Comprised of the mandatory field 'category' (string) and optional fields 'label' (string), 'value' (integer), 'noninteraction' (boolean), and 'hitcallback' (function) (Note: hitcallback is ignored in some versions of Google Analytics)
    *
    * @link https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#SettingUpEventTracking
    *
@@ -39,8 +39,8 @@ angular.module('angulartics.google.analytics', ['angulartics'])
   $analyticsProvider.registerEventTrack(function (action, properties) {
 
     // do nothing if there is no category (it's required by GA)
-    if (!properties || !properties.category) { 
-		return; 
+    if (!properties || !properties.category) {
+		return;
 	}
     // GA requires that eventValue be an integer, see:
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
@@ -59,7 +59,8 @@ angular.module('angulartics.google.analytics', ['angulartics'])
 		eventAction: action || null,
 		eventLabel: properties.label ||  null,
 		eventValue: properties.value || null,
-		nonInteraction: properties.noninteraction || null
+		nonInteraction: properties.noninteraction || null,
+    hitCallback: properties.hitcallback || null
 	  };
 
 	  // add custom dimensions and metrics


### PR DESCRIPTION
Until something like #169 is done and this is available across all services, basic support for the built-in ability to get a callback in newer versions of GA would be useful. GA-specific parameters are already exposed, so this seems in line with existing behavior.