### PR TITLE
In bower.json include only main script

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,23 +2,7 @@
   "name": "angulartics",
   "version": "0.17.2",
   "main": [
-    "src/angulartics.js",
-    "src/angulartics-adobe.js",
-    "src/angulartics-chartbeat.js",
-    "src/angulartics-cnzz.js",
-    "src/angulartics-flurry.js",
-    "src/angulartics-ga-cordova.js",
-    "src/angulartics-ga.js",
-    "src/angulartics-gtm.js",
-    "src/angulartics-kissmetrics.js",
-    "src/angulartics-mixpanel.js",
-    "src/angulartics-piwik.js",
-    "src/angulartics-scroll.js",
-    "src/angulartics-segmentio.js",
-    "src/angulartics-splunk.js",
-    "src/angulartics-woopra.js",
-    "src/angulartics-marketo.js",
-    "src/angulartics-intercom.js"
+    "src/angulartics.js"
   ],
   "dependencies": {
     "angular": ">= 1.1.5",


### PR DESCRIPTION
Let users choose their own providers. Adding all of them at once proves useless for many, since they're using only one or two providers. Just a suggestion :)