### PR TITLE
Add a timeout function around the data layer push for page views.

### DIFF
--- a/src/angulartics-gtm.js
+++ b/src/angulartics-gtm.js
@@ -26,10 +26,12 @@ angular.module('angulartics.google.tagmanager', ['angulartics'])
 
 	$analyticsProvider.registerPageTrack(function(path){
 		var dataLayer = window.dataLayer = window.dataLayer || [];
+		setTimeout(function() {
 		dataLayer.push({
 			'event': 'content-view',
 			'content-name': path
 		});
+		}, 500);
 	});
 
 	/**


### PR DESCRIPTION
I ran into a problem when tracking virtual page views with route change success and dynamic page titles. Both the titles and the page views are triggered from route change success but the page view gets triggered before the page titles are set. In Google analytics the title from the previous page is recorded instead of the page title for the active route. Adding the timeout function solves this problem.