### PR TITLE
Set event name for Google Tag Manager from properties

### DIFF
--- a/src/angulartics-gtm.js
+++ b/src/angulartics-gtm.js
@@ -43,7 +43,7 @@ angular.module('angulartics.google.tagmanager', ['angulartics'])
 	$analyticsProvider.registerEventTrack(function(action, properties){
 		var dataLayer = window.dataLayer = window.dataLayer || [];
 		dataLayer.push({
-			'event': 'interaction',
+			'event': properties.event || 'interaction',
 			'target': properties.category,
 			'action': action,
 			'target-properties': properties.label,


### PR DESCRIPTION
I think it will be better if event name for Google Tag Manager can be changed from properties.