### PR TITLE
Allow set event name for Google Tag Manager

### DIFF
--- a/src/angulartics-gtm.js
+++ b/src/angulartics-gtm.js
@@ -42,8 +42,9 @@ angular.module('angulartics.google.tagmanager', ['angulartics'])
 
 	$analyticsProvider.registerEventTrack(function(action, properties){
 		var dataLayer = window.dataLayer = window.dataLayer || [];
+		properties = properties || {};
 		dataLayer.push({
-			'event': 'interaction',
+			'event': properties.event || 'interaction',
 			'target': properties.category,
 			'action': action,
 			'target-properties': properties.label,


### PR DESCRIPTION
I think it will be better if event name for Google Tag Manager can be changed from properties.