### PR TITLE
(chore): Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.sublime-*
 npm-debug.log
 .idea
+.versions

--- a/package.js
+++ b/package.js
@@ -1,0 +1,36 @@
+// package metadata file for Meteor.js
+var packageName = 'urigo:angulartics'; // https://atmospherejs.com/urigo/angulartics
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+var version = '0.17.2';
+
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: 'angulartics (official): Analytics for AngularJS applications',
+  git: 'git@github.com:luisfarzati/angulartics.git'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+  api.use('angularjs:angular@1.1.5', where);
+  api.use('jquery-waypoints@1.0.3', where);
+
+  api.addFiles('dist/angulartics.min.js', where);
+  api.addFiles('dist/angulartics-adobe.min.js', where);
+  api.addFiles('dist/angulartics-chartbeat.min.js', where);
+  api.addFiles('dist/angulartics-cnzz.min.js', where);
+  api.addFiles('dist/angulartics-flurry.min.js', where);
+  api.addFiles('dist/angulartics-ga.min.js', where);
+  api.addFiles('dist/angulartics-ga-cordova.min.js', where);
+  api.addFiles('dist/angulartics-gtm.min.js', where);
+  api.addFiles('dist/angulartics-kissmetrics.min.js', where);
+  api.addFiles('dist/angulartics-mixpanel.min.js', where);
+  api.addFiles('dist/angulartics-piwik.min.js', where);
+  api.addFiles('dist/angulartics-scroll.min.js', where);
+  api.addFiles('dist/angulartics-segmentio.min.js', where);
+  api.addFiles('dist/angulartics-splunk.min.js', where);
+  api.addFiles('dist/angulartics-woopra.min.js', where);
+  api.addFiles('dist/angulartics-marketo.min.js', where);
+  api.addFiles('dist/angulartics-intercom.min.js', where);
+});

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 // package metadata file for Meteor.js
 var packageName = 'urigo:angulartics'; // https://atmospherejs.com/urigo/angulartics
 var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
-var version = '0.17.2';
+var version = '0.17.2_1';
 
 Package.describe({
   name: packageName,
@@ -13,7 +13,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
 
-  api.use('angularjs:angular@1.1.5', where);
+  api.use('angular:angular@1.1.5', where);
   api.use('jquery-waypoints@1.0.3', where);
 
   api.addFiles('dist/angulartics.min.js', where);


### PR DESCRIPTION
Hi

I'm a package maintainer for [Meteor.js](https://www.meteor.com/), a popular [full-stack JavaScript framework](https://github.com/meteor/meteor).

I'm also the creator of [angular-meteor](http://angularjs.meteor.com/), a library that let's you work with AngularJS on top of Meteor.

This PR will allow you to directly publish updated versions of angulartics as they become available.
I've already published the current version of the package on Atmosphere (Meteor's package directory). 

To make this under your username all you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, you will be able to publish the package under you name and I will delete mine.

There are also grunt scripts to help you publish to Meteor automaticly, here is an example:
https://github.com/MeteorPackaging/ui-router/commit/8f2e39e9780dee19201b4982ff6bbd98cf9f8770

Thanks & best regards,
Uri