### PR TITLE
Assigned the default event category "Event", as it's required by Google

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -53,9 +53,10 @@ angular.module('angulartics.google.analytics', ['angulartics'])
    */
   $analyticsProvider.registerEventTrack(function (action, properties) {
 
-    // do nothing if there is no category (it's required by GA)
+    // Google Analytics requires an Event Category
     if (!properties || !properties.category) {
-		return;
+    	properties = properties || {};
+		properties.category = 'Event';
 	}
     // GA requires that eventValue be an integer, see:
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue


### PR DESCRIPTION
Per the discussion in https://github.com/luisfarzati/angulartics/issues/81, I've added a default event category of "Event" to prevent events getting dropped without warning.