### PR TITLE
Omniture page tracking not getting path #248

### DIFF
--- a/src/angulartics-adobe.js
+++ b/src/angulartics-adobe.js
@@ -18,7 +18,7 @@ angular.module('angulartics.adobe.analytics', ['angulartics'])
   $analyticsProvider.settings.trackRelativePath = true;
 
   $analyticsProvider.registerPageTrack(function (path) {
-    if (window.s) s.t([path]);
+    if (window.s) s.t({pageName:path});
   });
 
   /**


### PR DESCRIPTION
Omniture page tracking not getting path #248.
Using an object instead of an array works for page tracking with omniture.