### PR TITLE
SessionCam plugin

### DIFF
--- a/src/angulartics-sessioncam.js
+++ b/src/angulartics-sessioncam.js
@@ -16,10 +16,9 @@
 
     // Notify SessionCam on route change
     $analyticsProvider.registerPageTrack(function (path) {
-      if(window.sessionCamRecorder) {
-        if(window.sessionCamRecorder.createVirtualPageLoad) {
-          window.sessionCamRecorder.createVirtualPageLoad(path);
-        }
+      var sessionCamRecorder = window.sessionCamRecorder;
+      if(sessionCamRecorder && sessionCamRecorder.createVirtualPageLoad) {
+        sessionCamRecorder.createVirtualPageLoad(path);
       }
     });
   }]);

--- a/src/angulartics-sessioncam.js
+++ b/src/angulartics-sessioncam.js
@@ -1,0 +1,26 @@
+/**
+ * (c) 2015 Mozio, inc https://github.com/mozioinc
+ * Contributed by http://github.com/caioflandau
+ * License: MIT
+ */
+(function (angular) {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   * @name angulartics.sessioncam
+   * Enables automatic virtual pageview support for SessionCam
+   */
+  angular.module('angulartics.sessioncam', ['angulartics'])
+  .config(['$analyticsProvider', function ($analyticsProvider) {
+
+    // Notify SessionCam on route change
+    $analyticsProvider.registerPageTrack(function (path) {
+      if(window.sessionCamRecorder) {
+        if(window.sessionCamRecorder.createVirtualPageLoad) {
+          window.sessionCamRecorder.createVirtualPageLoad(path);
+        }
+      }
+    });
+  }]);
+})(angular);


### PR DESCRIPTION
Just a very simple plugin to support SessionCam virtual page views automatically. Let me know if anyone needs any other features!

To implement it, all you need to do is inject the `angulartics.sessioncam` module and it does the rest.