### PR TITLE
Resolves #329 by updating to waypoints 3.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,12 +22,15 @@
   ],
   "dependencies": {
     "angular": ">= 1.1.5",
-    "waypoints": "~2.0.3",
+    "waypoints": "~3.1.1",
     "SHA-1": "*"
   },
   "devDependencies": {
     "angular-mocks": ">= 1.1.5",
     "angular-route": "~1.2",
     "angular-ui-router": "~0.2"
+  },
+  "resolutions": {
+    "angular": ">= 1.1.5"
   }
 }


### PR DESCRIPTION
Updates to use waypoints 3.1.1 which removes jQuery dependency. All tests pass. 