### PR TITLE
Add support for Inspectlet 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "src/angulartics-splunk.js",
     "src/angulartics-woopra.js",
     "src/angulartics-marketo.js",
-    "src/angulartics-intercom.js"
+    "src/angulartics-intercom.js",
+    "src/angulartics-inspectlet.js"
   ],
   "dependencies": {
     "angular": ">= 1.1.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "omniture",
     "page tracking",
     "event tracking",
-    "scroll tracking"
+    "scroll tracking",
+    "inspectlet"
   ],
   "bugs": {
     "url": "http://github.com/luisfarzati/angulartics/issues"

--- a/samples/inspectlet.html
+++ b/samples/inspectlet.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf8">
+	<title>Inspectlet sample | Angulartics</title>
+	<link rel="stylesheet" href="http://bootswatch.com/cosmo/bootstrap.min.css">
+	<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.1.5/angular.min.js"></script>
+	<script src="../src/angulartics.js"></script>
+	<script src="../src/angulartics-inspectlet.js"></script>
+	
+	<!-- Begin Inspectlet Embed Code -->
+	<script type="text/javascript" id="inspectletjs">
+		window.__insp = window.__insp || [];
+		__insp.push(['wid', ]);
+		(function() {
+			function __ldinsp(){var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = "inspsync"; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js'; var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); }
+			if (window.attachEvent) window.attachEvent('onload', __ldinsp);
+			else window.addEventListener('load', __ldinsp, false);
+		})();
+	</script>
+	<!-- End Inspectlet Embed Code -->
+
+
+</head>
+<body ng-app="sample">
+
+	<div class="navbar navbar-default">
+		<div class="navbar-header">
+			<a class="navbar-brand" href="#/">My App</a>
+		</div>
+		<div>
+			<ul class="nav navbar-nav">
+				<li><a href="#/a">Page A</a></li>
+				<li><a href="#/b">Page B</a></li>
+				<li><a href="#/c">Page C</a></li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="container">
+		<div ng-view></div>
+		<hr>
+
+		<button analytics-on="click" analytics-event="Other"  class="btn btn-default">Button 1</button>
+
+		<!-- same as analytics-on="click", because 'click' is the default -->
+		<button analytics-on analytics-event="Download" analytics-category="Commands" class="btn btn-primary">Button 2</button>
+
+		<!-- same as analytics-event="Button 3", because is inferred from innerText -->
+		<button analytics-on analytics-category="Commands" class="btn btn-success">Button 3</button>
+
+		<hr>
+
+		<p class="alert alert-success">
+			Open the network inspector in your browser, click any of the nav options or buttons above and you'll see the analytics
+			request being executed. Then check <a class="alert-link" href="https://www.inspectlet.com/dashboard">your Inspectlet dashboard</a>.
+		</p>
+	</div>
+
+	<script>
+		angular.module('sample', ['angulartics', 'angulartics.inspectlet'])
+		.config(function ($routeProvider, $analyticsProvider) {
+			$routeProvider
+			.when('/', { templateUrl: '/samples/partials/root.tpl.html', controller: 'SampleCtrl' })
+			.when('/a', { templateUrl: '/samples/partials/a.tpl.html', controller: 'SampleCtrl' })
+			.when('/b', { templateUrl: '/samples/partials/b.tpl.html', controller: 'SampleCtrl' })
+			.when('/c', { templateUrl: '/samples/partials/c.tpl.html', controller: 'SampleCtrl' })
+			.otherwise({ redirectTo: '/' });
+		})
+		.controller('SampleCtrl', function () {});
+	</script>
+</body>
+</html>

--- a/src/angulartics-inspectlet.js
+++ b/src/angulartics-inspectlet.js
@@ -1,0 +1,51 @@
+/**
+ * @license Angulartics v0.17.2
+ * (c) 2013 Luis Farzati http://luisfarzati.github.io/angulartics
+ * Inspectlet support contributed by http://github.com/geordie--
+ * License: MIT
+ */
+(function(angular) {
+'use strict';
+
+/**
+ * @ngdoc overview
+ * @name angulartics.inspeclet
+ * Enables analytics support for Inspectlet (http://inspectlet.com)
+ */
+angular.module('angulartics.inspectlet', ['angulartics'])
+.config(['$analyticsProvider', function ($analyticsProvider) {
+
+	$analyticsProvider.registerPageTrack(function (path) {
+
+		var pageTrackArray = [];
+		pageTrackArray.push('virtualPage');
+
+		if(path){
+			pageTrackArray.push({url : path});
+		};
+
+	  __insp.push(pageTrackArray);
+
+	});
+
+	$analyticsProvider.registerEventTrack(function (action, properties) {
+
+		//Tag only if the action name is allowed by Inspectlet
+		if ( !(action == 'identify' || action == 'tagSession') ){
+			return;
+		}
+
+		if(properties.category){
+			delete properties.category;
+		}
+
+		var eventTrackArray = [];
+		eventTrackArray.push(action);
+		eventTrackArray.push(properties)
+
+		__insp.push(eventTrackArray);
+
+  });
+
+}]);
+})(angular);


### PR DESCRIPTION
I have added a plugin for supporting [Inspectlet](http://inspectlet.com) , a tool for recording video sessions.
Currently there's a basic support for pageTrack in a SPA context and a full support for eventTrack.