### PR TITLE
html5 mode enabled events with current page

### DIFF
--- a/src/angulartics-ga.js
+++ b/src/angulartics-ga.js
@@ -79,7 +79,7 @@ angular.module('angulartics.google.analytics', ['angulartics'])
         eventLabel: properties.label,
         eventValue: properties.value,
         nonInteraction: properties.noninteraction,
-        page: properties.page || window.location.hash.substring(1),
+        page: properties.page || window.location.hash.substring(1) || window.location.pathname,
         userId: $analyticsProvider.settings.ga.userId
       };
 


### PR DESCRIPTION
If you're not using hashes, `window.location.hash` will return `""` and therefore the current page will not be sent with ga - only the first registered page view.