### PR TITLE
Properly escaping the path to build the event

### DIFF
--- a/src/angulartics-segmentio.js
+++ b/src/angulartics-segmentio.js
@@ -23,7 +23,7 @@
       // (string, object) is (name, properties)
       $analyticsProvider.registerPageTrack(function (path) {
         try {
-          analytics.page(path);
+          analytics.page(encodeURIComponent(path));
         } catch (e) {
           if (!(e instanceof ReferenceError)) {
             throw e;


### PR DESCRIPTION
This is required because some of the Segment integrations, in my case Keen.io, failed to read the literal url path (e.g `/tabs/person`) unless it was properly escaped, (e.g `%2Ftabs%2Fpage`). This happens since keen's send the event as a GET param.
For example, if the event is `"Viewed /tabs/competition Page"` you might end up with url like:
`https://api.keen.io/3.0/projects/<project_key>/events/Viewed%20/tabs/competition%20Page (...continued)` for which Keen throws a 404.