### PR TITLE
Improvement piwik plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ Setup listeners in Google Tag Manager
 
     angular.module('myApp', ['angulartics', 'angulartics.piwik'])
 
-Set piwik tracker code as you would normally somewhere on your page
+Set piwik tracker code as you would normally somewhere on your page, but make
+sure that you remove or comment the initial pageview tracking line (Angulartics will track
+the page when the first state is loaded).
 
     <!-- Piwik -->
     <script type="text/javascript">
       var _paq = _paq || [];
-      _paq.push(['trackPageView']);
+      // _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
         var u="//piwik.yourdomain.com/";

--- a/samples/piwik.html
+++ b/samples/piwik.html
@@ -10,7 +10,7 @@
 	<!-- Piwik -->
 	<script type="text/javascript">
 	  var _paq = _paq || [];
-	  _paq.push(["trackPageView"]);
+	  // _paq.push(["trackPageView"]);
 	  _paq.push(["enableLinkTracking"]);
 
 	  (function() {

--- a/src/angulartics-piwik.js
+++ b/src/angulartics-piwik.js
@@ -16,8 +16,9 @@
      * Enables analytics support for Piwik (http://piwik.org/docs/tracking-api/)
      */
     angular.module('angulartics.piwik', ['angulartics'])
-        .config(['$analyticsProvider',
-            function($analyticsProvider) {
+        .config(['$analyticsProvider', '$windowProvider',
+            function($analyticsProvider, $windowProvider) {
+                var $window = $windowProvider.$get();
 
                 $analyticsProvider.settings.pageTracking.trackRelativePath = true;
 
@@ -25,18 +26,18 @@
 
                 // scope: visit or page. Defaults to 'page'
                 $analyticsProvider.api.setCustomVariable = function(varIndex, varName, value, scope) {
-                    if (window._paq) {
+                    if ($window._paq) {
                         scope = scope || 'page';
-                        _paq.push(['setCustomVariable', varIndex, varName, value, scope]);
-                        _paq.push(['trackPageView']);
+                        $window._paq.push(['setCustomVariable', varIndex, varName, value, scope]);
+                        $window._paq.push(['trackPageView']);
                     }
-                }
+                };
 
                 // trackSiteSearch(keyword, category, [searchCount])
                 $analyticsProvider.api.trackSiteSearch = function(keyword, category, searchCount) {
 
                     // keyword is required
-                    if (window._paq && keyword) {
+                    if ($window._paq && keyword) {
 
                         var params = ['trackSiteSearch', keyword, category || false];
 
@@ -45,14 +46,14 @@
                             params.push(searchCount);
                         }
 
-                        _paq.push(params);
+                        $window._paq.push(params);
                     }
                 };
 
                 // logs a conversion for goal 1. revenue is optional
                 // trackGoal(goalID, [revenue]);
                 $analyticsProvider.api.trackGoal = function(goalID, revenue) {
-                    if (window._paq) {
+                    if ($window._paq) {
                         _paq.push(['trackGoal', goalID, revenue || 0]);
                     }
                 };
@@ -62,9 +63,9 @@
                 // $analytics.setUsername(username)
                 $analyticsProvider.registerSetUsername(function(username) {
 
-                    if (window._paq) {
-                        _paq.push(['setUserId', username]);
-                        _paq.push(['trackPageView']);
+                    if ($window._paq) {
+                        $window._paq.push(['setUserId', username]);
+                        $window._paq.push(['trackPageView']);
                     }
                 });
 
@@ -82,24 +83,24 @@
                 // TODO: Need a way for this to receive the title for the page
                 $analyticsProvider.registerPageTrack(function(path, locationObj) {
 
-                    if (window._paq) {
-                        // _paq.push(['setDocumentTitle', 'TODO']);
-                        _paq.push(['setCustomUrl', path]);
-                        _paq.push(['trackPageView']);
+                    if ($window._paq) {
+                        // $window._paq.push(['setDocumentTitle', 'TODO']);
+                        $window._paq.push(['setCustomUrl', path]);
+                        $window._paq.push(['trackPageView']);
                     }
                 });
 
                 // trackEvent(category, event, [name], [value])
                 $analyticsProvider.registerEventTrack(function(action, properties) {
 
-                    if (window._paq) {
+                    if ($window._paq) {
                         // PAQ requires that eventValue be an integer, see: http://piwik.org/docs/event-tracking/
                         if (properties.value) {
                             var parsed = parseInt(properties.value, 10);
                             properties.value = isNaN(parsed) ? 0 : parsed;
                         }
 
-                        _paq.push(['trackEvent', properties.category, action, properties.label, properties.value]);
+                        $window._paq.push(['trackEvent', properties.category, action, properties.label, properties.value]);
                     }
                 });
 

--- a/src/angulartics-piwik.js
+++ b/src/angulartics-piwik.js
@@ -77,11 +77,9 @@
                 // });
 
                 // locationObj is the angular $location object
-                // TODO: Need a way for this to receive the title for the page
                 $analyticsProvider.registerPageTrack(function(path, locationObj) {
-
                     if ($window._paq) {
-                        // $window._paq.push(['setDocumentTitle', 'TODO']);
+                        $window._paq.push(['setDocumentTitle', $window.document.title]);
                         $window._paq.push(['setCustomUrl', path]);
                         $window._paq.push(['trackPageView']);
                     }

--- a/src/angulartics-piwik.js
+++ b/src/angulartics-piwik.js
@@ -29,7 +29,6 @@
                     if ($window._paq) {
                         scope = scope || 'page';
                         $window._paq.push(['setCustomVariable', varIndex, varName, value, scope]);
-                        $window._paq.push(['trackPageView']);
                     }
                 };
 
@@ -62,10 +61,8 @@
 
                 // $analytics.setUsername(username)
                 $analyticsProvider.registerSetUsername(function(username) {
-
                     if ($window._paq) {
                         $window._paq.push(['setUserId', username]);
-                        $window._paq.push(['trackPageView']);
                     }
                 });
 
@@ -92,7 +89,6 @@
 
                 // trackEvent(category, event, [name], [value])
                 $analyticsProvider.registerEventTrack(function(action, properties) {
-
                     if ($window._paq) {
                         // PAQ requires that eventValue be an integer, see: http://piwik.org/docs/event-tracking/
                         if (properties.value) {


### PR DESCRIPTION
Hiya, I've made three changes here which (I think) improve the Piwik Plugin:

##### Use `$window` to access globals #####

This is not necessarily needed, but is a style improvement (in my opinion). The angular way to access globals is via `$window` to improve testability.

##### Removal of page tracks #####

Some of the methods reported page tracks every time they were used. This is not needed and just decreases the accuracy. It is important to note that e.g. `setUser` just sets an internal variable which will be used on the next page track. This means it must be called before the initial track (e.g. in a `.config` or `.run` block)
Furthermore I suggest to remove the tracking line provided by the Piwik JS snippet (the same as for GA) for the same reason.

##### Set document title #####

This was my main caveat with the current piwik plugin. The browser title is stored in `$document`. Luckily both `$window` and `$document` are globals so you can safely access them. I already used with dynamic browser titles and it works really well.

Looking forward to hear your thoughs!