### PR TITLE
Added `Facebook Pixel` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ the page when the first state is loaded).
 * [Adobe Analytics](https://github.com/angulartics/angulartics-adobe-analytics)
 * [Chartbeat](https://github.com/angulartics/angulartics-chartbeat)
 * Clicky
+* [Facebook Pixel] (https://github.com/mooyoul/angulartics-facebook-pixel)
 * [Flurry](https://github.com/angulartics/angulartics-flurry)
 * [Google Analytics](https://github.com/angulartics/angulartics-google-analytics)
 * Google Tag Manager


### PR DESCRIPTION
Hi. I just wrote Facebook Pixel Plugin for Angulartics.
It does satisfy [Plugin Contribution Rules](https://github.com/luisfarzati/angulartics/wiki/Plugin-contribution-rules).
so, I added this to Supported Providers.

BTW, I want to transfer this plugin from my own repo  to `angulartics` org repo, If you can help this repo transfering, please let me know. :smile: 

